### PR TITLE
Fix issue with Spotify widget skipping ads

### DIFF
--- a/src/components/spotify.tsx
+++ b/src/components/spotify.tsx
@@ -8,6 +8,7 @@ async function NowPlayingWidget() {
     const nowPlaying = await setSpotifyStatus();
 
     if (!nowPlaying) return;
+    if (nowPlaying.currently_playing_type=="ad") return;
 
     let artists = nowPlaying.item.artists.map((artist: { name: string; }) => artist.name).join(", ");
     if (artists.length > 10) {

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -43,7 +43,10 @@ export async function setSpotifyStatus() {
   const now_playing = await getNowPlaying();
 
   if (now_playing) {
-    console.log("Now playing:", now_playing.item.name);
+    if (now_playing.currently_playing_type === "track") {
+      //console.log(now_playing);
+      console.log("Now playing:", now_playing.item.name);
+    }
   } else {
     console.log("Not playing anything.");
   }


### PR DESCRIPTION
This pull request fixes an issue with the Spotify widget where it was skipping ads. The code now checks if the currently playing item is an ad before proceeding.